### PR TITLE
Fixed issue where setting border color a bunch would break things

### DIFF
--- a/NZCircularImageView/NZCircularImageView.m
+++ b/NZCircularImageView/NZCircularImageView.m
@@ -171,6 +171,18 @@
         shape.strokeColor       = self.borderColor.CGColor;
         shape.fillColor         = [UIColor clearColor].CGColor;
         shape.position          = point;
+        
+        shape.name = @"borderLayer";
+        
+        // remove old border layer if needed
+        for (CAShapeLayer *layer in self.layer.sublayers)
+        {
+            if ([layer.name isEqualToString:@"borderLayer"])
+            {
+                [layer removeFromSuperlayer];
+                break;
+            }
+        }
 
         [self.layer addSublayer:shape];
     }


### PR DESCRIPTION
I found this issue when making a button set out of `NZCircularImageView`. Tapping a button would set the border color to purple, and the previously selected button to gray. I noticed that tapping a button 50+ times would start to cause a lag (I had a `.1` second animation occur on the button). 

I found that every time the border color setter was called, it was adding a new `CAShapeLayer` on top, without taking the previous border shape into consideration. The end result was a view with 50+ unneccesary shape layers on top
